### PR TITLE
Fix: Restore Access to Interactive Preview Menus

### DIFF
--- a/finimalism7.css
+++ b/finimalism7.css
@@ -643,7 +643,7 @@ progress::-webkit-progress-value {
 }
 
 .countIndicator {
-  background: linear-gradient(to right, rgba(163, 95, 198, 0.7) 0%, rgba(6, 161, 217, 0.7) 100%);
+  background: rgba(var(--indicator),0.8);
   box-shadow: none;
 }
 


### PR DESCRIPTION
This pull request addresses the issue reported in [Issue #9](https://github.com/tedhinklater/finimalism/issues/9#issue-2603746006). The change made in line 646 of the last pull request was causing the bug associated with commit f66f249.

In this update, I am reverting only line 646 to its previous state, while keeping the rest of the changes from commit f66f249 intact, as they are not the cause of the bug.

Please review the changes to ensure the issue is resolved. Thank you!