### PR TITLE
FIX movie detail buttons and information. >1500 max-width

### DIFF
--- a/finimalism10.11.css
+++ b/finimalism10.11.css
@@ -3040,7 +3040,7 @@ a[href*="shokoanime.com"] {
   }
 }
 
-@media (max-height: 900px) and (max-width: 1500px) {
+@media (max-height: 900px) {
   .layout-desktop body {
     font-size: 80% !important;
   }


### PR DESCRIPTION
**Issue**
On screens with a width greater than 1500px and a height below 900px, the movie detail buttons and information (titles, names, and metadata) were not displayed correctly.
This happened because the font-size adjustment was only applied when both max-height and max-width conditions were met, excluding wide and ultrawide screens with limited vertical space.

**Solution**
The media query was simplified by removing the max-width condition, making the font-size adjustment depend only on the screen height:

`
@media (max-height: 900px) {
  .layout-desktop body {
    font-size: 80% !important;
  }
}
`

**Notes / Context**
I’m not fully sure this is the ideal or correct fix from a CSS perspective, as I’m not a CSS expert. However, this change does resolve the issue and restores the visibility of the detail buttons and movie information.

I also noticed that the max-width condition combined with and seems to have been added relatively recently. I’m not sure if there was a specific reason for it, but removing that condition makes the layout behave correctly again on wide screens with limited height.


**1500px or less always works well:**

<img width="2232" height="1123" alt="imagen" src="https://github.com/user-attachments/assets/aa51f7d3-d88d-47d2-83a3-e5b221d58ad0" />

Before / after for >1500px.

**Before:**
<img width="2243" height="1125" alt="imagen" src="https://github.com/user-attachments/assets/81c06190-6274-463a-ae6b-9ac9e9585558" />


**After:**
<img width="2248" height="1122" alt="imagen" src="https://github.com/user-attachments/assets/8bf9f5a2-657e-4f63-903d-4bb08ca0e067" />

